### PR TITLE
S3で一時ファイルが作成される様にモデルを修正

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,3 @@
 web: env RUBY_DEBUG_OPEN=true bin/rails server -b 0.0.0.0 -p 3000
 js: yarn build --watch
-css: yarn build:css --watchcss: yarn build:css --watch
+css: yarn build:css --watch

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -8,28 +8,36 @@ class Image < ApplicationRecord
 
   def process_image
     return unless file.attached?
-
     require "mini_magick"
+    downloaded = file.blob.download
 
-    # 一時ファイルを加工
-    downloaded = ActiveStorage::Blob.service.send(:path_for, file.blob.key)
-    image = MiniMagick::Image.open(downloaded)
+    Tempfile.create(["original", ".jpg"]) do |tempfile|
+      tempfile.binmode
+      tempfile.write(downloaded)
+      tempfile.rewind
 
-    # 加工内容（ここはお好みでどんどん追加できます）
-    image.combine_options do |c|
-      c.negate         # 色反転
-      c.contrast       # コントラスト強調
-      c.wave "5x80"    # 歪ませる
+      image = MiniMagick::Image.open(tempfile.path)
+
+      # 加工内容
+      image.combine_options do |c|
+        c.negate         # 色反転
+        c.contrast       # コントラスト強調
+        c.wave "5x80"    # 歪み
+      end
+
+      # 加工後のファイルを保存
+      processed_tempfile = Tempfile.new(["processed", ".jpg"])
+      image.write(processed_tempfile.path)
+
+      # ActiveStorageに添付
+      processed_file.attach(
+        io: File.open(processed_tempfile.path),
+        filename: "processed.jpg",
+        content_type: "image/jpeg"
+      )
+
+      processed_tempfile.close
+      processed_tempfile.unlink
     end
-
-    # 加工後のファイルを保存
-    temp_path = Rails.root.join("tmp", "processed_#{SecureRandom.hex(8)}.jpg")
-    image.write(temp_path)
-
-    # ActiveStorageに添付
-    processed_file.attach(io: File.open(temp_path), filename: "processed.jpg", content_type: "image/jpeg")
-
-    # 一時ファイル削除
-    File.delete(temp_path) if File.exist?(temp_path)
   end
 end


### PR DESCRIPTION
# 概要
S3環境でimageモデルのrocess_imageが動かないエラーが出ていたので、ローカル・本番を問わず動く様にコードを修正した。
